### PR TITLE
Update rubyzip to the latest version

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,7 +2,7 @@ source "http://rubygems.org"
 # Add dependencies required to use your gem here.
 # Example:
 #   gem "activesupport", ">= 2.3.5"
-gem "rubyzip", "<1.0.0"
+gem 'rubyzip', '>= 1.0.0'
 
 # Add dependencies to develop your gem here.
 # Include everything needed to run rake, tests, features, etc.

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -53,7 +53,7 @@ GEM
     rspec-expectations (2.11.3)
       diff-lcs (~> 1.1.3)
     rspec-mocks (2.11.3)
-    rubyzip (0.9.9)
+    rubyzip (1.1.7)
     simplecov (0.7.1)
       multi_json (~> 1.0)
       simplecov-html (~> 0.7.1)
@@ -68,6 +68,6 @@ DEPENDENCIES
   jeweler (~> 1.8.7)
   redcarpet
   rspec (~> 2.11.0)
-  rubyzip (< 1.0.0)
+  rubyzip (>= 1.0.0)
   simplecov
   yard

--- a/lib/android/apk.rb
+++ b/lib/android/apk.rb
@@ -126,7 +126,7 @@ module Android
 
     # find and return zip entry with name
     # @param [String] name file name in apk(fullpath)
-    # @return [Zip::ZipEntry] zip entry object
+    # @return [Zip::Entry] zip entry object
     # @raise [NotFoundError] when 'name' doesn't exist in the apk
     def entry(name)
       entry = @zip.find_entry(name)

--- a/lib/android/apk.rb
+++ b/lib/android/apk.rb
@@ -1,4 +1,4 @@
-require 'zip/zip' # need rubyzip gem -> doc: http://rubyzip.sourceforge.net/
+require 'zip' # need rubyzip gem -> doc: http://rubyzip.sourceforge.net/
 require 'digest/md5'
 require 'digest/sha1'
 require 'digest/sha2'
@@ -42,7 +42,7 @@ module Android
       begin
         @zip = Zip::ZipFile.open(@path)
       rescue Zip::ZipError => e
-        raise NotApkFileError, e.message 
+        raise NotApkFileError, e.message
       end
 
       @bindata = File.open(@path, 'rb') {|f| f.read }
@@ -161,7 +161,7 @@ module Android
       if /^@(\w+\/\w+)|(0x[0-9a-fA-F]{8})$/ =~ icon_id
         drawables = @resource.find(icon_id)
         Hash[drawables.map {|name| [name, file(name)] }]
-      else 
+      else
         { icon_id => file(icon_id) } # ugh!: not tested!!
       end
     end

--- a/lib/android/apk.rb
+++ b/lib/android/apk.rb
@@ -40,8 +40,8 @@ module Android
       @path = filepath
       raise NotFoundError, "'#{filepath}'" unless File.exist? @path
       begin
-        @zip = Zip::ZipFile.open(@path)
-      rescue Zip::ZipError => e
+        @zip = Zip::File.open(@path)
+      rescue Zip::Error => e
         raise NotApkFileError, e.message
       end
 

--- a/ruby_apk.gemspec
+++ b/ruby_apk.gemspec
@@ -68,7 +68,7 @@ Gem::Specification.new do |s|
     s.specification_version = 4
 
     if Gem::Version.new(Gem::VERSION) >= Gem::Version.new('1.2.0') then
-      s.add_runtime_dependency(%q<rubyzip>, ["< 1.0.0"])
+      s.add_runtime_dependency(%q<rubyzip>, [">= 1.0.0"])
       s.add_development_dependency(%q<rspec>, ["~> 2.11.0"])
       s.add_development_dependency(%q<bundler>, [">= 1.1.5"])
       s.add_development_dependency(%q<jeweler>, ["~> 1.8.7"])
@@ -76,7 +76,7 @@ Gem::Specification.new do |s|
       s.add_development_dependency(%q<redcarpet>, [">= 0"])
       s.add_development_dependency(%q<simplecov>, [">= 0"])
     else
-      s.add_dependency(%q<rubyzip>, ["< 1.0.0"])
+      s.add_dependency(%q<rubyzip>, [">= 1.0.0"])
       s.add_dependency(%q<rspec>, ["~> 2.11.0"])
       s.add_dependency(%q<bundler>, [">= 1.1.5"])
       s.add_dependency(%q<jeweler>, ["~> 1.8.7"])
@@ -85,7 +85,7 @@ Gem::Specification.new do |s|
       s.add_dependency(%q<simplecov>, [">= 0"])
     end
   else
-    s.add_dependency(%q<rubyzip>, ["< 1.0.0"])
+    s.add_dependency(%q<rubyzip>, [">= 1.0.0"])
     s.add_dependency(%q<rspec>, ["~> 2.11.0"])
     s.add_dependency(%q<bundler>, [">= 1.1.5"])
     s.add_dependency(%q<jeweler>, ["~> 1.8.7"])

--- a/spec/apk_spec.rb
+++ b/spec/apk_spec.rb
@@ -1,6 +1,6 @@
 require File.expand_path(File.dirname(__FILE__) + '/spec_helper')
 require 'tempfile'
-require 'zip/zip'
+require 'zip'
 require 'digest/sha1'
 require 'digest/sha2'
 require 'digest/md5'
@@ -127,7 +127,7 @@ describe Android::Apk do
   its(:bindata) { should be_instance_of String }
   describe '#bindata' do
     specify 'encoding should be ASCII-8BIT' do
-      subject.bindata.encoding.should eq Encoding::ASCII_8BIT 
+      subject.bindata.encoding.should eq Encoding::ASCII_8BIT
     end
   end
 
@@ -142,7 +142,7 @@ describe Android::Apk do
 
   describe "#size" do
     subject { apk.size }
-    it "should return apk file size" do 
+    it "should return apk file size" do
       should == File.size(tmp_path)
     end
   end

--- a/spec/apk_spec.rb
+++ b/spec/apk_spec.rb
@@ -18,12 +18,12 @@ class TempApk
     File.unlink(@path) if File.exist? @path
   end
   def append(entry_name, data)
-    Zip::ZipFile.open(@path, Zip::ZipFile::CREATE) { |zip|
+    Zip::File.open(@path, Zip::File::CREATE) { |zip|
       zip.get_output_stream(entry_name) {|f| f.write data }
     }
   end
   def remove(entry_name)
-    Zip::ZipFile.open(@path, Zip::ZipFile::CREATE) { |zip|
+    Zip::File.open(@path, Zip::File::CREATE) { |zip|
       zip.remove(entry_name)
     }
   end
@@ -228,14 +228,14 @@ describe Android::Apk do
     before do
       tmp_apk.append("hoge.txt", "aaaaaaa")
     end
-    it { expect { |b| apk.each_entry(&b) }.to yield_successive_args(Zip::ZipEntry, Zip::ZipEntry, Zip::ZipEntry) }
+    it { expect { |b| apk.each_entry(&b) }.to yield_successive_args(Zip::Entry, Zip::Entry, Zip::Entry) }
   end
 
   describe '#entry' do
     subject { apk.entry(entry_name) }
     context 'assigns exist entry' do
       let(:entry_name) { 'AndroidManifest.xml' }
-      it { should be_instance_of Zip::ZipEntry }
+      it { should be_instance_of Zip::Entry }
     end
     context 'assigns not exist entry name' do
       let(:entry_name) { 'not_exist_path' }


### PR DESCRIPTION
The Rubyzip interface has changed! No need to do require "zip/zip" and Zip prefix in class names removed. 